### PR TITLE
Making apt-get more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM node:5.1.0
 
 LABEL "code"="Van Gogh"
 
-RUN apt-get update
-RUN apt-get install -qqy libjpeg62-turbo-dev libpango1.0-dev libgif-dev build-essential g++
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    g++ \
+    libgif-dev \
+    libjpeg62-turbo-dev \
+    libpango1.0-dev
 
 WORKDIR /var/www
 


### PR DESCRIPTION
Я однажы столкнулся с проблемой. У меня, как и у тебя было написано `apt-get update` на одной строке, а `apt-get install ...` — на другой. Я много собриал этот образ — `apt-get update` не менялся и всегда брался из докерного кеша. А `apt-get install ...` иногда изменялся. В какой-то момент времени после очередного измнения `apt-get install ...` стал завершаться с ошибкой. Оказалось, что удаленный deb репоизиторий там что-то перестроил и мета инфорация, которая была сохранена в докерном кеше уже перестала быть правильной. Потому, лучше размещать apt-get update и apt-get install в виде одной докерной команды, чтобы изменение списка пакетов аатоматически приводило к выполнению apt-get update.

Кроме этого тут еще несколько изменений, которые я считаю хорошими:
- каждый пакет теперь находится на одельной строке — проще читать Dockerfile и проще читать diff с изменениями
- пакеты теперь находятся в отсортированном порядке — когда пакетов много есть возможность допустить ошибку — указать один и тот же пакет несколько раз. В случае если они отсортированы, эта ошибка бросается в глаза.
- убрать -qq у apt-get install — лучше писать больше логово чем меньше, если сборка образа зависает надолго, и в консоль ничего нет, то это приводит в замешательство.
