### PR TITLE
Simplifying Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get install -qqy libjpeg62-turbo-dev libpango1.0-dev libgif-dev build-es
 
 WORKDIR /var/www
 
-COPY ./package.json /var/www/package.json
+ADD ./package.json /var/www/
 RUN npm i
 
-COPY ./index.js /var/www/index.js
-COPY ./vincent-van-gogh.png /var/www/vincent-van-gogh.png
+ADD ./index.js /var/www/
+ADD ./vincent-van-gogh.png /var/www/
 
 CMD test -d ascii && node index.js > ascii/vincent.txt


### PR DESCRIPTION
При использовании ADD или COPY можно не указать полное имя файла — так проще и писать и читать. Но тут есть подводный камень — нужно чтобы папка назначения обязательно заканчивалась на `/`

Вообще есть разница между ADD и COPY ( http://stackoverflow.com/questions/24958140/docker-copy-vs-add ), но в моей практике она ни разу не была существена, а ADD писать проще (меньше символов)
