### PR TITLE
Showing errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN npm i
 COPY ./index.js /var/www/index.js
 COPY ./vincent-van-gogh.png /var/www/vincent-van-gogh.png
 
-CMD test -d ascii && node index.js > ascii/vincent.txt
+CMD node index.js > ascii/vincent.txt


### PR DESCRIPTION
Текущий образ работает так. Если не указать папку, то контейнер молча завершится с ошибкой:

```
$ docker run vincent; echo $?
1
```

А после этого имзнения при неправильном запуске появится текст ошибки н и станет чуть-чуть понятнее что было сделано неправильно:

```
$ docker run vincent; echo $?
/bin/sh: 1: cannot create ascii/vincent.txt: Directory nonexistent
2
```
